### PR TITLE
Prevent expo-av from crashing in bare apps

### DIFF
--- a/packages/expo-av/ios/EXAV/EXAudioSessionManager.m
+++ b/packages/expo-av/ios/EXAV/EXAudioSessionManager.m
@@ -74,7 +74,11 @@ UM_REGISTER_SINGLETON_MODULE(AudioSessionManager);
 + (NSString *)getExperienceIdFromScopedModule:(id)scopedModule
 {
   if ([scopedModule respondsToSelector:@selector(experienceId)]) {
-    return [scopedModule experienceId];
+    NSString *experienceId = [scopedModule experienceId];
+    if (experienceId) {
+      return experienceId;
+    }
+    return @"BARE";
   }
   return nil;
 }


### PR DESCRIPTION
Temporary workaround for #3864, since bare apps have no `experienceId` which causes a crash.

I've verified that this stops the app from crashing in iOS. 👍 